### PR TITLE
Update more links to removed site

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -72,7 +72,7 @@
 				<p>Kustomize introduces a template-free way to customize application configuration that simplifies the use of off-the-shelf applications. Now, built into <code>kubectl</code> as <code>apply -k</code>.
 				</p>
 				<div class="flex buttons">
-					<a href="https://kubernetes-sigs.github.io/kustomize/installation/" class="Button primary darkBlue">Install kustomize </a>
+					<a href="https://kubectl.docs.kubernetes.io/installation/kustomize/" class="Button primary darkBlue">Install kustomize </a>
 					<a href="https://kubectl.docs.kubernetes.io/guides/introduction/" class="Button secondary white">Use with kubectl</a>
 				</div>
 			</div>
@@ -143,7 +143,7 @@
     </div>
     <div class="container">
         <div class="documentation-link">
-            See Documentation: <a href="https://kubectl.docs.kubernetes.io/pages/app_management/introduction.html" target="_blank">apply -k</a> | <a href="https://kubernetes-sigs.github.io/kustomize/" target="_blank">standalone</a>
+            See Documentation: <a href="https://kubectl.docs.kubernetes.io/guides/config_management/introduction/" target="_blank">apply -k</a> | <a href="https://kubectl.docs.kubernetes.io/references/kustomize/" target="_blank">standalone</a>
         </div>
     </div>
 </div>
@@ -166,7 +166,7 @@
                       for Kubernetes<span class="arrow"></span></p>
                 </div>
               </a>
-              <a href="https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/declarative-application-management.md" target="_blank">
+              <a href="https://github.com/kubernetes/design-proposals-archive/blob/main/architecture/declarative-application-management.md" target="_blank">
                 <div class="card">
                     <h4>Background Whitepaper
                     </h4>
@@ -187,7 +187,7 @@
                     <p>A great overview of key Kustomize concepts.<span class="arrow"></span></p>
                 </div>
               </a>
-              <a href="https://kubernetes-sigs.github.io/kustomize/api-reference/glossary/" target="_blank">
+              <a href="https://kubectl.docs.kubernetes.io/references/kustomize/glossary/" target="_blank">
                 <div class="card">
                     <h4>Glossary
                     </h4>
@@ -341,7 +341,7 @@
                     <p>GitHub</p>
                 </div>
               </a>
-              <a href="https://groups.google.com/forum/#!forum/kubernetes-sig-cli" target="_blank">
+              <a href="https://groups.google.com/g/kubernetes-sig-cli" target="_blank">
                 <div class="link">
                     <div class="link-icon envelope"></div>
                     <p>Official</br>

--- a/themes/replicated-docs-theme/layouts/partials/community_section.html
+++ b/themes/replicated-docs-theme/layouts/partials/community_section.html
@@ -22,7 +22,7 @@
                     <p>GitHub</p>
                 </div>
               </a>
-              <a href="https://groups.google.com/forum/#!forum/kubernetes-sig-cli" target="_blank">
+              <a href="https://groups.google.com/g/kubernetes-sig-cli" target="_blank">
                 <div class="link">
                     <div class="link-icon envelope"></div>
                     <p>Official</br>

--- a/themes/replicated-docs-theme/layouts/partials/header.html
+++ b/themes/replicated-docs-theme/layouts/partials/header.html
@@ -64,8 +64,8 @@
 				<p>Kustomize introduces a template-free way to customize application configuration that simplifies the use of off-the-shelf applications. Now, built into <code>kubectl</code> as <code>apply -k</code>.
 				</p>
 				<div class="flex buttons">
-					<a href="https://kubernetes-sigs.github.io/kustomize/installation/" class="Button primary darkBlue">Install kustomize </a>
-					<a href="https://kubectl.docs.kubernetes.io/guides/introduction/" class="Button secondary white">Use with kubectl</a>
+					<a href="https://kubectl.docs.kubernetes.io/installation/kustomize/" class="Button primary darkBlue">Install kustomize </a>
+					<a href="https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/" class="Button secondary white">Use with kubectl</a>
 				</div>
 			</div>
 			<div class="template-illustration flex1">

--- a/themes/replicated-docs-theme/layouts/partials/overview_section.html
+++ b/themes/replicated-docs-theme/layouts/partials/overview_section.html
@@ -58,7 +58,7 @@
     </div>
     <div class="container">
         <div class="documentation-link">
-            See Documentation: <a href="https://kubectl.docs.kubernetes.io/pages/app_management/introduction.html" target="_blank">apply -k</a> | <a href="https://kubernetes-sigs.github.io/kustomize/" target="_blank">standalone</a>
+            See Documentation: <a href="https://kubectl.docs.kubernetes.io/guides/config_management/introduction/" target="_blank">apply -k</a> | <a href="https://kubectl.docs.kubernetes.io/references/kustomize/" target="_blank">standalone</a>
         </div>
     </div>
 </div>

--- a/themes/replicated-docs-theme/layouts/partials/resources_section.html
+++ b/themes/replicated-docs-theme/layouts/partials/resources_section.html
@@ -16,7 +16,7 @@
                       for Kubernetes<span class="arrow"></span></p>
                 </div>
               </a>
-              <a href="https://github.com/kubernetes/community/blob/master/contributors/design-proposals/architecture/declarative-application-management.md" target="_blank">
+              <a href="https://github.com/kubernetes/design-proposals-archive/blob/main/architecture/declarative-application-management.md" target="_blank">
                 <div class="card">
                     <h4>Background Whitepaper
                     </h4>
@@ -37,7 +37,7 @@
                     <p>A great overview of key Kustomize concepts.<span class="arrow"></span></p>
                 </div>
               </a>
-              <a href="https://kubernetes-sigs.github.io/kustomize/api-reference/glossary/" target="_blank">
+              <a href="https://kubectl.docs.kubernetes.io/references/kustomize/glossary/" target="_blank">
                 <div class="card">
                     <h4>Glossary
                     </h4>
@@ -68,7 +68,7 @@
                        in kubectl through the -k flag <span class="arrow"></span></p>
                 </div>
               </a>
-              <a href="https://kubernetes.io/blog/2019/03/25/kubernetes-1-14-release-announcement/" target="_blank">
+              <a href="https://kubectl.docs.kubernetes.io/guides/introduction/kustomize/" target="_blank">
                 <div class="card">
                     <h4>Kustomize Introduction
                     </h4>


### PR DESCRIPTION
Follow up to https://github.com/replicatedcom/kustomize-www/pull/19

For https://github.com/kubernetes-sigs/kustomize/issues/4500, which pointed out that there were additional places kustomize.io points to the old site I've now deactivated. I also fixed a few other links that didn't work or went the wrong place while I'm here.